### PR TITLE
Add repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "component": "component install && component build --use component-builder-suit",
     "component-dev": "component install --dev && component build --dev --use component-builder-suit",
     "preprocess": "suitcss build/build.css build/build.css"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/utils-size.git"
   }
 }


### PR DESCRIPTION
Just to get rid of the annoying npm warning

```
npm WARN package.json suitcss-utils-size@0.6.2 No repository field.
```
