### PR TITLE
`npm run build-test` fails - Fix index css path

### DIFF
--- a/test/test.css
+++ b/test/test.css
@@ -3,4 +3,4 @@
 @custom-media --lg-viewport (min-width:960px);
 
 @import "suitcss-components-test";
-@import "./index.css";
+@import "../index.css";


### PR DESCRIPTION
I've noticed this possible issue in most of the utils-* repositories. Most components-* have the updated path and don't fail `npm run build-test`. I'll be happy to fix them all if this is a definite issue and not my mistake.