### PR TITLE
Add flex-basis to support new flexbox grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,17 @@
 
 [![Build Status](https://secure.travis-ci.org/suitcss/utils-size.png?branch=master)](http://travis-ci.org/suitcss/utils-size)
 
-SUIT CSS sizing utilities.
+SUIT CSS sizing utilities. Sets `width` and `flex-basis`.
 
 Read more about [SUIT CSS's design principles](https://github.com/suitcss/suit/).
 
 ## Installation
 
 * [npm](http://npmjs.org/): `npm install suitcss-utils-size`
-* [Component(1)](http://component.io/): `component install suitcss/utils-size`
-* [Bower](http://bower.io/): `bower install suit-utils-size`
 * Download: [zip](https://github.com/suitcss/utils-size/zipball/master)
 
 ## Available classes
 
-* `u-sizeFit` - Make an element shrink wrap its content by floating left.
-* `u-sizeFitAlt` - Make an element shrink wrap its content by floating right.
-* `u-sizeFill` - Make an element fill the remaining space.
-* `u-sizeFillAlt` - An alternative method to make an element fill the remaining space.
-* `u-sizeFull` - Make an element the width of its parent.
 * `u-sizeXofY` (numerous) - Specify the proportional width of an object.
 
 `X` must be an integer less than `Y`.
@@ -42,7 +35,7 @@ There are 3 Media Query breakpoints:
 * `--md-viewport`
 * `--lg-viewport`
 
-When using the [SUIT CSS preprocessor](https://github.com/suitcss/preprocessor),
+When using the [postcss-custom-media](https://github.com/postcss/postcss-custom-media),
 breakpoints can be configured using `@custom-media`. For example:
 
 ```css

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are 3 Media Query breakpoints:
 * `--md-viewport`
 * `--lg-viewport`
 
-When using the [postcss-custom-media](https://github.com/postcss/postcss-custom-media),
+When using [postcss-custom-media](https://github.com/postcss/postcss-custom-media),
 breakpoints can be configured using `@custom-media`. For example:
 
 ```css

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Read more about [SUIT CSS's design principles](https://github.com/suitcss/suit/)
 
 ## Available classes
 
+* `u-sizeFull` - Make an element the width of its parent.
+* `u-sizeFill` - Make an element fill the remaining space.
 * `u-sizeXofY` (numerous) - Specify the proportional width of an object.
 
 `X` must be an integer less than `Y`.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ Basic visual tests are in `test/index.html`.
 
 ## Browser support
 
+Refer to the [caniuse](http://caniuse.com/) page for [flexbox](http://caniuse.com/#feat=flexbox).
+This package can still be used in older browsers if `width` is required
+
 * Google Chrome (latest)
 * Opera (latest)
-* Firefox 4+
-* Safari 5+
-* Internet Explorer 8+
+* Firefox 28+
+* Safari 6.1+
+* Internet Explorer 10+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ To generate the testing build.
 npm run build-test
 ```
 
+To watch the files for making changes to test:
+
+```
+npm run watch
+```
+
 Basic visual tests are in `test/index.html`.
 
 ## Browser support

--- a/build.js
+++ b/build.js
@@ -1,0 +1,17 @@
+const postcss = require('postcss');
+const bemLinter = require('postcss-bem-linter');
+const reporter = require('postcss-reporter');
+
+module.exports = {
+  use: [
+    "postcss-import",
+    "postcss-calc",
+    "postcss-custom-media",
+    "autoprefixer"
+  ],
+  "postcss-import": {
+    transform(css) {
+      return postcss([bemLinter, reporter]).process(css).css;
+    }
+  }
+};

--- a/build.js
+++ b/build.js
@@ -7,11 +7,15 @@ module.exports = {
     "postcss-import",
     "postcss-calc",
     "postcss-custom-media",
-    "autoprefixer"
+    "autoprefixer",
+    "postcss-reporter"
   ],
   "postcss-import": {
     transform(css) {
       return postcss([bemLinter, reporter]).process(css).css;
     }
+  },
+  "postcss-reporter": {
+    clearMessages: true
   }
 };

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -5,6 +5,27 @@
 
 @media (--lg-viewport) {
 
+  /* Intrinsic widths
+     ========================================================================== */
+
+  /**
+   * Make an element fill the remaining space.
+   */
+
+  .u-lg-sizeFill {
+    flex: 1 !important;
+  }
+
+  /**
+   * Make an element the width of its parent.
+   */
+
+  .u-lg-sizeFull {
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
+  }
+
   /* Proportional widths: breakpoint 3 (large)
      ========================================================================== */
 

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -1,56 +1,9 @@
 /**
+ * @define utilities
  * Size: breakpoint 3 (large)
  */
 
 @media (--lg-viewport) {
-
-  /**
-   * Make an element shrink wrap its content.
-   */
-
-  .u-lg-sizeFit,
-  .u-lg-sizeFitAlt {
-    display: block !important;
-    float: left !important;
-    width: auto !important;
-  }
-
-  .u-lg-sizeFitAlt {
-    float: right !important;
-  }
-
-  /**
-   * Make an element fill the remaining space.
-   * N.B. This will hide overflow.
-   */
-
-  .u-lg-sizeFill {
-    display: block !important;
-    overflow: hidden !important;
-    width: auto !important;
-  }
-
-  /**
-   * An alternative method to make an element fill the remaining space.
-   * N.B. Do not use if child elements might be wider than the remaining space.
-   * In Chrome, Safari, and Firefox it results in undesired layout.
-   */
-
-  .u-lg-sizeFillAlt {
-    display: table-cell !important;
-    max-width: 100% !important;
-    width: 10000px !important;
-  }
-
-  /**
-   * Make an element the width of its parent.
-   */
-
-  .u-lg-sizeFull {
-    box-sizing: border-box !important;
-    display: block !important;
-    width: 100% !important;
-  }
 
   /* Proportional widths: breakpoint 3 (large)
      ========================================================================== */
@@ -62,53 +15,64 @@
    */
 
   .u-lg-size1of12 {
+    flex-basis: calc(100% * 1 / 12) !important;
     width: calc(100% * 1 / 12) !important;
   }
 
   .u-lg-size1of10 {
+    flex-basis: 10% !important;
     width: 10% !important;
   }
 
   .u-lg-size1of8 {
+    flex-basis: 12.5% !important;
     width: 12.5% !important;
   }
 
   .u-lg-size1of6,
   .u-lg-size2of12 {
+    flex-basis: calc(100% * 1 / 6) !important;
     width: calc(100% * 1 / 6) !important;
   }
 
   .u-lg-size1of5,
   .u-lg-size2of10 {
+    flex-basis: 20% !important;
     width: 20% !important;
   }
 
   .u-lg-size1of4,
   .u-lg-size2of8,
   .u-lg-size3of12 {
+    flex-basis: 25% !important;
     width: 25% !important;
   }
 
   .u-lg-size3of10 {
+    flex-basis: 30% !important;
     width: 30% !important;
   }
 
   .u-lg-size1of3,
   .u-lg-size2of6,
   .u-lg-size4of12 {
+    flex-basis: calc(100% * 1 / 3) !important;
     width: calc(100% * 1 / 3) !important;
   }
 
   .u-lg-size3of8 {
+    flex-basis: 37.5% !important;
     width: 37.5% !important;
   }
 
   .u-lg-size2of5,
   .u-lg-size4of10 {
+    flex-basis: 40% !important;
     width: 40% !important;
   }
 
   .u-lg-size5of12 {
+    flex-basis: calc(100% * 5 / 12) !important;
     width: calc(100% * 5 / 12) !important;
   }
 
@@ -118,57 +82,69 @@
   .u-lg-size4of8,
   .u-lg-size5of10,
   .u-lg-size6of12 {
+    flex-basis: 50% !important;
     width: 50% !important;
   }
 
   .u-lg-size7of12 {
+    flex-basis: calc(100% * 7 / 12) !important;
     width: calc(100% * 7 / 12) !important;
   }
 
   .u-lg-size3of5,
   .u-lg-size6of10 {
+    flex-basis: 60% !important;
     width: 60% !important;
   }
 
   .u-lg-size5of8 {
+    flex-basis: 62.5% !important;
     width: 62.5% !important;
   }
 
   .u-lg-size2of3,
   .u-lg-size4of6,
   .u-lg-size8of12 {
+    flex-basis: calc(100% * 2 / 3) !important;
     width: calc(100% * 2 / 3) !important;
   }
 
   .u-lg-size7of10 {
+    flex-basis: 70% !important;
     width: 70% !important;
   }
 
   .u-lg-size3of4,
   .u-lg-size6of8,
   .u-lg-size9of12 {
+    flex-basis: 75% !important;
     width: 75% !important;
   }
 
   .u-lg-size4of5,
   .u-lg-size8of10 {
+    flex-basis: 80% !important;
     width: 80% !important;
   }
 
   .u-lg-size5of6,
   .u-lg-size10of12 {
+    flex-basis: calc(100% * 5 / 6) !important;
     width: calc(100% * 5 / 6) !important;
   }
 
   .u-lg-size7of8 {
+    flex-basis: 87.5% !important;
     width: 87.5% !important;
   }
 
   .u-lg-size9of10 {
+    flex-basis: 90% !important;
     width: 90% !important;
   }
 
   .u-lg-size11of12 {
+    flex-basis: calc(100% * 11 / 12) !important;
     width: calc(100% * 11 / 12) !important;
   }
 

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -32,67 +32,70 @@
    * Specify the proportional width of an object.
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
+   *
+   * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
+   * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
    */
 
   .u-lg-size1of12 {
-    flex-basis: calc(100% * 1 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 12) !important;
   }
 
   .u-lg-size1of10 {
-    flex-basis: 10% !important;
+    flex-basis: auto !important;
     width: 10% !important;
   }
 
   .u-lg-size1of8 {
-    flex-basis: 12.5% !important;
+    flex-basis: auto !important;
     width: 12.5% !important;
   }
 
   .u-lg-size1of6,
   .u-lg-size2of12 {
-    flex-basis: calc(100% * 1 / 6) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 6) !important;
   }
 
   .u-lg-size1of5,
   .u-lg-size2of10 {
-    flex-basis: 20% !important;
+    flex-basis: auto !important;
     width: 20% !important;
   }
 
   .u-lg-size1of4,
   .u-lg-size2of8,
   .u-lg-size3of12 {
-    flex-basis: 25% !important;
+    flex-basis: auto !important;
     width: 25% !important;
   }
 
   .u-lg-size3of10 {
-    flex-basis: 30% !important;
+    flex-basis: auto !important;
     width: 30% !important;
   }
 
   .u-lg-size1of3,
   .u-lg-size2of6,
   .u-lg-size4of12 {
-    flex-basis: calc(100% * 1 / 3) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 3) !important;
   }
 
   .u-lg-size3of8 {
-    flex-basis: 37.5% !important;
+    flex-basis: auto !important;
     width: 37.5% !important;
   }
 
   .u-lg-size2of5,
   .u-lg-size4of10 {
-    flex-basis: 40% !important;
+    flex-basis: auto !important;
     width: 40% !important;
   }
 
   .u-lg-size5of12 {
-    flex-basis: calc(100% * 5 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 5 / 12) !important;
   }
 
@@ -102,69 +105,69 @@
   .u-lg-size4of8,
   .u-lg-size5of10,
   .u-lg-size6of12 {
-    flex-basis: 50% !important;
+    flex-basis: auto !important;
     width: 50% !important;
   }
 
   .u-lg-size7of12 {
-    flex-basis: calc(100% * 7 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 7 / 12) !important;
   }
 
   .u-lg-size3of5,
   .u-lg-size6of10 {
-    flex-basis: 60% !important;
+    flex-basis: auto !important;
     width: 60% !important;
   }
 
   .u-lg-size5of8 {
-    flex-basis: 62.5% !important;
+    flex-basis: auto !important;
     width: 62.5% !important;
   }
 
   .u-lg-size2of3,
   .u-lg-size4of6,
   .u-lg-size8of12 {
-    flex-basis: calc(100% * 2 / 3) !important;
+    flex-basis: auto !important;
     width: calc(100% * 2 / 3) !important;
   }
 
   .u-lg-size7of10 {
-    flex-basis: 70% !important;
+    flex-basis: auto !important;
     width: 70% !important;
   }
 
   .u-lg-size3of4,
   .u-lg-size6of8,
   .u-lg-size9of12 {
-    flex-basis: 75% !important;
+    flex-basis: auto !important;
     width: 75% !important;
   }
 
   .u-lg-size4of5,
   .u-lg-size8of10 {
-    flex-basis: 80% !important;
+    flex-basis: auto !important;
     width: 80% !important;
   }
 
   .u-lg-size5of6,
   .u-lg-size10of12 {
-    flex-basis: calc(100% * 5 / 6) !important;
+    flex-basis: auto !important;
     width: calc(100% * 5 / 6) !important;
   }
 
   .u-lg-size7of8 {
-    flex-basis: 87.5% !important;
+    flex-basis: auto !important;
     width: 87.5% !important;
   }
 
   .u-lg-size9of10 {
-    flex-basis: 90% !important;
+    flex-basis: auto !important;
     width: 90% !important;
   }
 
   .u-lg-size11of12 {
-    flex-basis: calc(100% * 11 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 11 / 12) !important;
   }
 

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -10,15 +10,14 @@
 
   /**
    * Make an element fill the remaining space.
+   *
+   * Be explicit to workaround IE10 bug with shorthand flex
+   * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
    */
 
   .u-lg-sizeFill {
-    flex: 1 !important;
+    flex: 1 1 0% !important; /* 1 */
   }
-
-  /**
-   * Make an element the width of its parent.
-   */
 
   .u-lg-sizeFull {
     box-sizing: border-box !important;

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -11,10 +11,8 @@
   /**
    * Make an element fill the remaining space.
    *
-   * 1. Be explicit to work around IE10 bug with shorthand flex
-   *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
-   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
-   *    https://github.com/philipwalton/flexbugs/issues/92
+   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
    */
 
   .u-lg-sizeFill {
@@ -40,8 +38,7 @@
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
    *
-   * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
-   * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
+   * Uses `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11 - http://git.io/vllMD
    */
 
   .u-lg-size1of12 {

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -11,13 +11,20 @@
   /**
    * Make an element fill the remaining space.
    *
-   * Be explicit to workaround IE10 bug with shorthand flex
-   * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+   * 1. Be explicit to work around IE10 bug with shorthand flex
+   *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
+   *    https://github.com/philipwalton/flexbugs/issues/92
    */
 
   .u-lg-sizeFill {
     flex: 1 1 0% !important; /* 1 */
+    flex-basis: 0% !important; /* 2 */
   }
+
+  /**
+   * Make an element the width of its parent.
+   */
 
   .u-lg-sizeFull {
     box-sizing: border-box !important;

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -11,10 +11,8 @@
   /**
    * Make an element fill the remaining space.
    *
-   * 1. Be explicit to work around IE10 bug with shorthand flex
-   *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
-   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
-   *    https://github.com/philipwalton/flexbugs/issues/92
+   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
    */
 
   .u-md-sizeFill {
@@ -40,8 +38,7 @@
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
    *
-   * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
-   * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
+   * Uses `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11 - http://git.io/vllMD
    */
 
   .u-md-size1of12 {

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -36,67 +36,70 @@
    * Specify the proportional width of an object.
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
+   *
+   * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
+   * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
    */
 
   .u-md-size1of12 {
-    flex-basis: calc(100% * 1 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 12) !important;
   }
 
   .u-md-size1of10 {
-    flex-basis: 10% !important;
+    flex-basis: auto !important;
     width: 10% !important;
   }
 
   .u-md-size1of8 {
-    flex-basis: 12.5% !important;
+    flex-basis: auto !important;
     width: 12.5% !important;
   }
 
   .u-md-size1of6,
   .u-md-size2of12 {
-    flex-basis: calc(100% * 1 / 6) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 6) !important;
   }
 
   .u-md-size1of5,
   .u-md-size2of10 {
-    flex-basis: 20% !important;
+    flex-basis: auto !important;
     width: 20% !important;
   }
 
   .u-md-size1of4,
   .u-md-size2of8,
   .u-md-size3of12 {
-    flex-basis: 25% !important;
+    flex-basis: auto !important;
     width: 25% !important;
   }
 
   .u-md-size3of10 {
-    flex-basis: 30% !important;
+    flex-basis: auto !important;
     width: 30% !important;
   }
 
   .u-md-size1of3,
   .u-md-size2of6,
   .u-md-size4of12 {
-    flex-basis: calc(100% * 1 / 3) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 3) !important;
   }
 
   .u-md-size3of8 {
-    flex-basis: 37.5% !important;
+    flex-basis: auto !important;
     width: 37.5% !important;
   }
 
   .u-md-size2of5,
   .u-md-size4of10 {
-    flex-basis: 40% !important;
+    flex-basis: auto !important;
     width: 40% !important;
   }
 
   .u-md-size5of12 {
-    flex-basis: calc(100% * 5 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 5 / 12) !important;
   }
 
@@ -106,69 +109,69 @@
   .u-md-size4of8,
   .u-md-size5of10,
   .u-md-size6of12 {
-    flex-basis: 50% !important;
+    flex-basis: auto !important;
     width: 50% !important;
   }
 
   .u-md-size7of12 {
-    flex-basis: calc(100% * 7 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 7 / 12) !important;
   }
 
   .u-md-size3of5,
   .u-md-size6of10 {
-    flex-basis: 60% !important;
+    flex-basis: auto !important;
     width: 60% !important;
   }
 
   .u-md-size5of8 {
-    flex-basis: 62.5% !important;
+    flex-basis: auto !important;
     width: 62.5% !important;
   }
 
   .u-md-size2of3,
   .u-md-size4of6,
   .u-md-size8of12 {
-    flex-basis: calc(100% * 2 / 3) !important;
+    flex-basis: auto !important;
     width: calc(100% * 2 / 3) !important;
   }
 
   .u-md-size7of10 {
-    flex-basis: 70% !important;
+    flex-basis: auto !important;
     width: 70% !important;
   }
 
   .u-md-size3of4,
   .u-md-size6of8,
   .u-md-size9of12 {
-    flex-basis: 75% !important;
+    flex-basis: auto !important;
     width: 75% !important;
   }
 
   .u-md-size4of5,
   .u-md-size8of10 {
-    flex-basis: 80% !important;
+    flex-basis: auto !important;
     width: 80% !important;
   }
 
   .u-md-size5of6,
   .u-md-size10of12 {
-    flex-basis: calc(100% * 5 / 6) !important;
+    flex-basis: auto !important;
     width: calc(100% * 5 / 6) !important;
   }
 
   .u-md-size7of8 {
-    flex-basis: 87.5% !important;
+    flex-basis: auto !important;
     width: 87.5% !important;
   }
 
   .u-md-size9of10 {
-    flex-basis: 90% !important;
+    flex-basis: auto !important;
     width: 90% !important;
   }
 
   .u-md-size11of12 {
-    flex-basis: calc(100% * 11 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 11 / 12) !important;
   }
 

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -5,6 +5,27 @@
 
 @media (--md-viewport) {
 
+  /* Intrinsic widths
+     ========================================================================== */
+
+  /**
+   * Make an element fill the remaining space.
+   */
+
+  .u-md-sizeFill {
+    flex: 1 !important;
+  }
+
+  /**
+   * Make an element the width of its parent.
+   */
+
+  .u-md-sizeFull {
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
+  }
+
   /* Proportional widths: breakpoint 2 (medium)
      ========================================================================== */
 

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -1,56 +1,9 @@
 /**
+ * @define utilities
  * Size: breakpoint 2 (medium)
  */
 
 @media (--md-viewport) {
-
-  /**
-   * Make an element shrink wrap its content.
-   */
-
-  .u-md-sizeFit,
-  .u-md-sizeFitAlt {
-    display: block !important;
-    float: left !important;
-    width: auto !important;
-  }
-
-  .u-md-sizeFitAlt {
-    float: right !important;
-  }
-
-  /**
-   * Make an element fill the remaining space.
-   * N.B. This will hide overflow.
-   */
-
-  .u-md-sizeFill {
-    display: block !important;
-    overflow: hidden !important;
-    width: auto !important;
-  }
-
-  /**
-   * An alternative method to make an element fill the remaining space.
-   * N.B. Do not use if child elements might be wider than the remaining space.
-   * In Chrome, Safari, and Firefox it results in undesired layout.
-   */
-
-  .u-md-sizeFillAlt {
-    display: table-cell !important;
-    max-width: 100% !important;
-    width: 10000px !important;
-  }
-
-  /**
-   * Make an element the width of its parent.
-   */
-
-  .u-md-sizeFull {
-    box-sizing: border-box !important;
-    display: block !important;
-    width: 100% !important;
-  }
 
   /* Proportional widths: breakpoint 2 (medium)
      ========================================================================== */
@@ -62,53 +15,64 @@
    */
 
   .u-md-size1of12 {
+    flex-basis: calc(100% * 1 / 12) !important;
     width: calc(100% * 1 / 12) !important;
   }
 
   .u-md-size1of10 {
+    flex-basis: 10% !important;
     width: 10% !important;
   }
 
   .u-md-size1of8 {
+    flex-basis: 12.5% !important;
     width: 12.5% !important;
   }
 
   .u-md-size1of6,
   .u-md-size2of12 {
+    flex-basis: calc(100% * 1 / 6) !important;
     width: calc(100% * 1 / 6) !important;
   }
 
   .u-md-size1of5,
   .u-md-size2of10 {
+    flex-basis: 20% !important;
     width: 20% !important;
   }
 
   .u-md-size1of4,
   .u-md-size2of8,
   .u-md-size3of12 {
+    flex-basis: 25% !important;
     width: 25% !important;
   }
 
   .u-md-size3of10 {
+    flex-basis: 30% !important;
     width: 30% !important;
   }
 
   .u-md-size1of3,
   .u-md-size2of6,
   .u-md-size4of12 {
+    flex-basis: calc(100% * 1 / 3) !important;
     width: calc(100% * 1 / 3) !important;
   }
 
   .u-md-size3of8 {
+    flex-basis: 37.5% !important;
     width: 37.5% !important;
   }
 
   .u-md-size2of5,
   .u-md-size4of10 {
+    flex-basis: 40% !important;
     width: 40% !important;
   }
 
   .u-md-size5of12 {
+    flex-basis: calc(100% * 5 / 12) !important;
     width: calc(100% * 5 / 12) !important;
   }
 
@@ -118,57 +82,69 @@
   .u-md-size4of8,
   .u-md-size5of10,
   .u-md-size6of12 {
+    flex-basis: 50% !important;
     width: 50% !important;
   }
 
   .u-md-size7of12 {
+    flex-basis: calc(100% * 7 / 12) !important;
     width: calc(100% * 7 / 12) !important;
   }
 
   .u-md-size3of5,
   .u-md-size6of10 {
+    flex-basis: 60% !important;
     width: 60% !important;
   }
 
   .u-md-size5of8 {
+    flex-basis: 62.5% !important;
     width: 62.5% !important;
   }
 
   .u-md-size2of3,
   .u-md-size4of6,
   .u-md-size8of12 {
+    flex-basis: calc(100% * 2 / 3) !important;
     width: calc(100% * 2 / 3) !important;
   }
 
   .u-md-size7of10 {
+    flex-basis: 70% !important;
     width: 70% !important;
   }
 
   .u-md-size3of4,
   .u-md-size6of8,
   .u-md-size9of12 {
+    flex-basis: 75% !important;
     width: 75% !important;
   }
 
   .u-md-size4of5,
   .u-md-size8of10 {
+    flex-basis: 80% !important;
     width: 80% !important;
   }
 
   .u-md-size5of6,
   .u-md-size10of12 {
+    flex-basis: calc(100% * 5 / 6) !important;
     width: calc(100% * 5 / 6) !important;
   }
 
   .u-md-size7of8 {
+    flex-basis: 87.5% !important;
     width: 87.5% !important;
   }
 
   .u-md-size9of10 {
+    flex-basis: 90% !important;
     width: 90% !important;
   }
 
   .u-md-size11of12 {
+    flex-basis: calc(100% * 11 / 12) !important;
     width: calc(100% * 11 / 12) !important;
   }
 

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -10,10 +10,13 @@
 
   /**
    * Make an element fill the remaining space.
+   *
+   * Be explicit to workaround IE10 bug with shorthand flex
+   * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
    */
 
   .u-md-sizeFill {
-    flex: 1 !important;
+    flex: 1 1 0% !important; /* 1 */
   }
 
   /**

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -11,12 +11,15 @@
   /**
    * Make an element fill the remaining space.
    *
-   * Be explicit to workaround IE10 bug with shorthand flex
-   * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+   * 1. Be explicit to work around IE10 bug with shorthand flex
+   *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
+   *    https://github.com/philipwalton/flexbugs/issues/92
    */
 
   .u-md-sizeFill {
     flex: 1 1 0% !important; /* 1 */
+    flex-basis: 0% !important; /* 2 */
   }
 
   /**

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -10,10 +10,13 @@
 
   /**
    * Make an element fill the remaining space.
+   *
+   * Be explicit to workaround IE10 bug with shorthand flex
+   * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
    */
 
   .u-sm-sizeFill {
-    flex: 1 !important;
+    flex: 1 1 0% !important; /* 1 */
   }
 
   /**

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -11,10 +11,8 @@
   /**
    * Make an element fill the remaining space.
    *
-   * 1. Be explicit to work around IE10 bug with shorthand flex
-   *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
-   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
-   *    https://github.com/philipwalton/flexbugs/issues/92
+   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
    */
 
   .u-sm-sizeFill {
@@ -40,8 +38,7 @@
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
    *
-   * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
-   * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
+   * Uses `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11 - http://git.io/vllMD
    */
 
   .u-sm-size1of12 {

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -5,6 +5,27 @@
 
 @media (--sm-viewport) {
 
+  /* Intrinsic widths
+     ========================================================================== */
+
+  /**
+   * Make an element fill the remaining space.
+   */
+
+  .u-sm-sizeFill {
+    flex: 1 !important;
+  }
+
+  /**
+   * Make an element the width of its parent.
+   */
+
+  .u-sm-sizeFull {
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
+  }
+
   /* Proportional widths: breakpoint 1 (small)
      ========================================================================== */
 

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -36,67 +36,70 @@
    * Specify the proportional width of an object.
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
+   *
+   * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
+   * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
    */
 
   .u-sm-size1of12 {
-    flex-basis: calc(100% * 1 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 12) !important;
   }
 
   .u-sm-size1of10 {
-    flex-basis: 10% !important;
+    flex-basis: auto !important;
     width: 10% !important;
   }
 
   .u-sm-size1of8 {
-    flex-basis: 12.5% !important;
+    flex-basis: auto !important;
     width: 12.5% !important;
   }
 
   .u-sm-size1of6,
   .u-sm-size2of12 {
-    flex-basis: calc(100% * 1 / 6) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 6) !important;
   }
 
   .u-sm-size1of5,
   .u-sm-size2of10 {
-    flex-basis: 20% !important;
+    flex-basis: auto !important;
     width: 20% !important;
   }
 
   .u-sm-size1of4,
   .u-sm-size2of8,
   .u-sm-size3of12 {
-    flex-basis: 25% !important;
+    flex-basis: auto !important;
     width: 25% !important;
   }
 
   .u-sm-size3of10 {
-    flex-basis: 30% !important;
+    flex-basis: auto !important;
     width: 30% !important;
   }
 
   .u-sm-size1of3,
   .u-sm-size2of6,
   .u-sm-size4of12 {
-    flex-basis: calc(100% * 1 / 3) !important;
+    flex-basis: auto !important;
     width: calc(100% * 1 / 3) !important;
   }
 
   .u-sm-size3of8 {
-    flex-basis: 37.5% !important;
+    flex-basis: auto !important;
     width: 37.5% !important;
   }
 
   .u-sm-size2of5,
   .u-sm-size4of10 {
-    flex-basis: 40% !important;
+    flex-basis: auto !important;
     width: 40% !important;
   }
 
   .u-sm-size5of12 {
-    flex-basis: calc(100% * 5 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 5 / 12) !important;
   }
 
@@ -106,69 +109,69 @@
   .u-sm-size4of8,
   .u-sm-size5of10,
   .u-sm-size6of12 {
-    flex-basis: 50% !important;
+    flex-basis: auto !important;
     width: 50% !important;
   }
 
   .u-sm-size7of12 {
-    flex-basis: calc(100% * 7 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 7 / 12) !important;
   }
 
   .u-sm-size3of5,
   .u-sm-size6of10 {
-    flex-basis: 60% !important;
+    flex-basis: auto !important;
     width: 60% !important;
   }
 
   .u-sm-size5of8 {
-    flex-basis: 62.5% !important;
+    flex-basis: auto !important;
     width: 62.5% !important;
   }
 
   .u-sm-size2of3,
   .u-sm-size4of6,
   .u-sm-size8of12 {
-    flex-basis: calc(100% * 2 / 3) !important;
+    flex-basis: auto !important;
     width: calc(100% * 2 / 3) !important;
   }
 
   .u-sm-size7of10 {
-    flex-basis: 70% !important;
+    flex-basis: auto !important;
     width: 70% !important;
   }
 
   .u-sm-size3of4,
   .u-sm-size6of8,
   .u-sm-size9of12 {
-    flex-basis: 75% !important;
+    flex-basis: auto !important;
     width: 75% !important;
   }
 
   .u-sm-size4of5,
   .u-sm-size8of10 {
-    flex-basis: 80% !important;
+    flex-basis: auto !important;
     width: 80% !important;
   }
 
   .u-sm-size5of6,
   .u-sm-size10of12 {
-    flex-basis: calc(100% * 5 / 6) !important;
+    flex-basis: auto !important;
     width: calc(100% * 5 / 6) !important;
   }
 
   .u-sm-size7of8 {
-    flex-basis: 87.5% !important;
+    flex-basis: auto !important;
     width: 87.5% !important;
   }
 
   .u-sm-size9of10 {
-    flex-basis: 90% !important;
+    flex-basis: auto !important;
     width: 90% !important;
   }
 
   .u-sm-size11of12 {
-    flex-basis: calc(100% * 11 / 12) !important;
+    flex-basis: auto !important;
     width: calc(100% * 11 / 12) !important;
   }
 

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -1,56 +1,9 @@
 /**
+ * @define utilities
  * Size: breakpoint 1 (small)
  */
 
 @media (--sm-viewport) {
-
-  /**
-   * Make an element shrink wrap its content.
-   */
-
-  .u-sm-sizeFit,
-  .u-sm-sizeFitAlt {
-    display: block !important;
-    float: left !important;
-    width: auto !important;
-  }
-
-  .u-sm-sizeFitAlt {
-    float: right !important;
-  }
-
-  /**
-   * Make an element fill the remaining space.
-   * N.B. This will hide overflow.
-   */
-
-  .u-sm-sizeFill {
-    display: block !important;
-    overflow: hidden !important;
-    width: auto !important;
-  }
-
-  /**
-   * An alternative method to make an element fill the remaining space.
-   * N.B. Do not use if child elements might be wider than the remaining space.
-   * In Chrome, Safari, and Firefox it results in undesired layout.
-   */
-
-  .u-sm-sizeFillAlt {
-    display: table-cell !important;
-    max-width: 100% !important;
-    width: 10000px !important;
-  }
-
-  /**
-   * Make an element the width of its parent.
-   */
-
-  .u-sm-sizeFull {
-    box-sizing: border-box !important;
-    display: block !important;
-    width: 100% !important;
-  }
 
   /* Proportional widths: breakpoint 1 (small)
      ========================================================================== */
@@ -62,53 +15,64 @@
    */
 
   .u-sm-size1of12 {
+    flex-basis: calc(100% * 1 / 12) !important;
     width: calc(100% * 1 / 12) !important;
   }
 
   .u-sm-size1of10 {
+    flex-basis: 10% !important;
     width: 10% !important;
   }
 
   .u-sm-size1of8 {
+    flex-basis: 12.5% !important;
     width: 12.5% !important;
   }
 
   .u-sm-size1of6,
   .u-sm-size2of12 {
+    flex-basis: calc(100% * 1 / 6) !important;
     width: calc(100% * 1 / 6) !important;
   }
 
   .u-sm-size1of5,
   .u-sm-size2of10 {
+    flex-basis: 20% !important;
     width: 20% !important;
   }
 
   .u-sm-size1of4,
   .u-sm-size2of8,
   .u-sm-size3of12 {
+    flex-basis: 25% !important;
     width: 25% !important;
   }
 
   .u-sm-size3of10 {
+    flex-basis: 30% !important;
     width: 30% !important;
   }
 
   .u-sm-size1of3,
   .u-sm-size2of6,
   .u-sm-size4of12 {
+    flex-basis: calc(100% * 1 / 3) !important;
     width: calc(100% * 1 / 3) !important;
   }
 
   .u-sm-size3of8 {
+    flex-basis: 37.5% !important;
     width: 37.5% !important;
   }
 
   .u-sm-size2of5,
   .u-sm-size4of10 {
+    flex-basis: 40% !important;
     width: 40% !important;
   }
 
   .u-sm-size5of12 {
+    flex-basis: calc(100% * 5 / 12) !important;
     width: calc(100% * 5 / 12) !important;
   }
 
@@ -118,57 +82,69 @@
   .u-sm-size4of8,
   .u-sm-size5of10,
   .u-sm-size6of12 {
+    flex-basis: 50% !important;
     width: 50% !important;
   }
 
   .u-sm-size7of12 {
+    flex-basis: calc(100% * 7 / 12) !important;
     width: calc(100% * 7 / 12) !important;
   }
 
   .u-sm-size3of5,
   .u-sm-size6of10 {
+    flex-basis: 60% !important;
     width: 60% !important;
   }
 
   .u-sm-size5of8 {
+    flex-basis: 62.5% !important;
     width: 62.5% !important;
   }
 
   .u-sm-size2of3,
   .u-sm-size4of6,
   .u-sm-size8of12 {
+    flex-basis: calc(100% * 2 / 3) !important;
     width: calc(100% * 2 / 3) !important;
   }
 
   .u-sm-size7of10 {
+    flex-basis: 70% !important;
     width: 70% !important;
   }
 
   .u-sm-size3of4,
   .u-sm-size6of8,
   .u-sm-size9of12 {
+    flex-basis: 75% !important;
     width: 75% !important;
   }
 
   .u-sm-size4of5,
   .u-sm-size8of10 {
+    flex-basis: 80% !important;
     width: 80% !important;
   }
 
   .u-sm-size5of6,
   .u-sm-size10of12 {
+    flex-basis: calc(100% * 5 / 6) !important;
     width: calc(100% * 5 / 6) !important;
   }
 
   .u-sm-size7of8 {
+    flex-basis: 87.5% !important;
     width: 87.5% !important;
   }
 
   .u-sm-size9of10 {
+    flex-basis: 90% !important;
     width: 90% !important;
   }
 
   .u-sm-size11of12 {
+    flex-basis: calc(100% * 11 / 12) !important;
     width: calc(100% * 11 / 12) !important;
   }
 

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -11,12 +11,15 @@
   /**
    * Make an element fill the remaining space.
    *
-   * Be explicit to workaround IE10 bug with shorthand flex
-   * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+   * 1. Be explicit to work around IE10 bug with shorthand flex
+   *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
+   *    https://github.com/philipwalton/flexbugs/issues/92
    */
 
   .u-sm-sizeFill {
     flex: 1 1 0% !important; /* 1 */
+    flex-basis: 0% !important; /* 2 */
   }
 
   /**

--- a/lib/size.css
+++ b/lib/size.css
@@ -10,10 +10,8 @@
 /**
  * Make an element fill the remaining space.
  *
- * 1. Be explicit to work around IE10 bug with shorthand flex
- *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
- * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
- *    https://github.com/philipwalton/flexbugs#13-importance-is-ignored-on-flex-basis-when-using-flex-shorthand
+ * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+ * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
  */
 
 .u-sizeFill {
@@ -40,8 +38,7 @@
  * Intentional redundancy build into each set of unit classes.
  * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
  *
- * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
- * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
+ * Uses `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11 - http://git.io/vllMD
  */
 
 .u-size1of12 {

--- a/lib/size.css
+++ b/lib/size.css
@@ -9,10 +9,13 @@
 
 /**
  * Make an element fill the remaining space.
+ *
+ * Be explicit to workaround IE10 bug with shorthand flex
+ * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
  */
 
 .u-sizeFill {
-  flex: 1 !important;
+  flex: 1 1 0% !important; /* 1 */
 }
 
 /**

--- a/lib/size.css
+++ b/lib/size.css
@@ -4,6 +4,28 @@
  * Sizing utilities
  */
 
+/* Intrinsic widths
+   ========================================================================== */
+
+/**
+ * Make an element fill the remaining space.
+ */
+
+.u-sizeFill {
+  flex: 1 !important;
+}
+
+/**
+ * Make an element the width of its parent.
+ */
+
+.u-sizeFull {
+  box-sizing: border-box !important;
+  display: block !important;
+  width: 100% !important;
+}
+
+
 /* Proportional widths
    ========================================================================== */
 

--- a/lib/size.css
+++ b/lib/size.css
@@ -36,67 +36,70 @@
  * Specify the proportional width of an object.
  * Intentional redundancy build into each set of unit classes.
  * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
+ *
+ * Uses `flex-basis: auto` with a width to work around box-sizing bug in IE10/11
+ * https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
  */
 
 .u-size1of12 {
-  flex-basis: calc(100% * 1 / 12) !important;
+  flex-basis: auto !important;
   width: calc(100% * 1 / 12) !important;
 }
 
 .u-size1of10 {
-  flex-basis: 10% !important;
+  flex-basis: auto !important;
   width: 10% !important;
 }
 
 .u-size1of8 {
-  flex-basis: 12.5% !important;
+  flex-basis: auto !important;
   width: 12.5% !important;
 }
 
 .u-size1of6,
 .u-size2of12 {
-  flex-basis: calc(100% * 1 / 6) !important;
+  flex-basis: auto !important;
   width: calc(100% * 1 / 6) !important;
 }
 
 .u-size1of5,
 .u-size2of10 {
-  flex-basis: 20% !important;
+  flex-basis: auto !important;
   width: 20% !important;
 }
 
 .u-size1of4,
 .u-size2of8,
 .u-size3of12 {
-  flex-basis: 25% !important;
+  flex-basis: auto !important;
   width: 25% !important;
 }
 
 .u-size3of10 {
-  flex-basis: 30% !important;
+  flex-basis: auto !important;
   width: 30% !important;
 }
 
 .u-size1of3,
 .u-size2of6,
 .u-size4of12 {
-  flex-basis: calc(100% * 1 / 3) !important;
+  flex-basis: auto !important;
   width: calc(100% * 1 / 3) !important;
 }
 
 .u-size3of8 {
-  flex-basis: 37.5% !important;
+  flex-basis: auto !important;
   width: 37.5% !important;
 }
 
 .u-size2of5,
 .u-size4of10 {
-  flex-basis: 40% !important;
+  flex-basis: auto !important;
   width: 40% !important;
 }
 
 .u-size5of12 {
-  flex-basis: calc(100% * 5 / 12) !important;
+  flex-basis: auto !important;
   width: calc(100% * 5 / 12) !important;
 }
 
@@ -106,68 +109,68 @@
 .u-size4of8,
 .u-size5of10,
 .u-size6of12 {
-  flex-basis: 50% !important;
+  flex-basis: auto !important;
   width: 50% !important;
 }
 
 .u-size7of12 {
-  flex-basis: calc(100% * 7 / 12) !important;
+  flex-basis: auto !important;
   width: calc(100% * 7 / 12) !important;
 }
 
 .u-size3of5,
 .u-size6of10 {
-  flex-basis: 60% !important;
+  flex-basis: auto !important;
   width: 60% !important;
 }
 
 .u-size5of8 {
-  flex-basis: 62.5% !important;
+  flex-basis: auto !important;
   width: 62.5% !important;
 }
 
 .u-size2of3,
 .u-size4of6,
 .u-size8of12 {
-  flex-basis: calc(100% * 2 / 3) !important;
+  flex-basis: auto !important;
   width: calc(100% * 2 / 3) !important;
 }
 
 .u-size7of10 {
-  flex-basis: 70% !important;
+  flex-basis: auto !important;
   width: 70% !important;
 }
 
 .u-size3of4,
 .u-size6of8,
 .u-size9of12 {
-  flex-basis: 75% !important;
+  flex-basis: auto !important;
   width: 75% !important;
 }
 
 .u-size4of5,
 .u-size8of10 {
-  flex-basis: 80% !important;
+  flex-basis: auto !important;
   width: 80% !important;
 }
 
 .u-size5of6,
 .u-size10of12 {
-  flex-basis: calc(100% * 5 / 6) !important;
+  flex-basis: auto !important;
   width: calc(100% * 5 / 6) !important;
 }
 
 .u-size7of8 {
-  flex-basis: 87.5% !important;
+  flex-basis: auto !important;
   width: 87.5% !important;
 }
 
 .u-size9of10 {
-  flex-basis: 90% !important;
+  flex-basis: auto !important;
   width: 90% !important;
 }
 
 .u-size11of12 {
-  flex-basis: calc(100% * 11 / 12) !important;
+  flex-basis: auto !important;
   width: calc(100% * 11 / 12) !important;
 }

--- a/lib/size.css
+++ b/lib/size.css
@@ -1,57 +1,8 @@
+
 /**
+ * @define utilities
  * Sizing utilities
  */
-
-/* Intrinsic widths
-   ========================================================================== */
-
-/**
- * Make an element shrink wrap its content.
- */
-
-.u-sizeFit,
-.u-sizeFitAlt {
-  display: block !important;
-  float: left !important;
-  width: auto !important;
-}
-
-.u-sizeFitAlt {
-  float: right !important;
-}
-
-/**
- * Make an element fill the remaining space.
- * N.B. This will hide overflow.
- */
-
-.u-sizeFill {
-  display: block !important;
-  overflow: hidden !important;
-  width: auto !important;
-}
-
-/**
- * An alternative method to make an element fill the remaining space.
- * N.B. Do not use if child elements might be wider than the remaining space.
- * In Chrome, Safari, and Firefox it results in undesired layout.
- */
-
-.u-sizeFillAlt {
-  display: table-cell !important;
-  max-width: 100% !important;
-  width: 10000px !important;
-}
-
-/**
- * Make an element the width of its parent.
- */
-
-.u-sizeFull {
-  box-sizing: border-box !important;
-  display: block !important;
-  width: 100% !important;
-}
 
 /* Proportional widths
    ========================================================================== */
@@ -63,53 +14,64 @@
  */
 
 .u-size1of12 {
+  flex-basis: calc(100% * 1 / 12) !important;
   width: calc(100% * 1 / 12) !important;
 }
 
 .u-size1of10 {
+  flex-basis: 10% !important;
   width: 10% !important;
 }
 
 .u-size1of8 {
+  flex-basis: 12.5% !important;
   width: 12.5% !important;
 }
 
 .u-size1of6,
 .u-size2of12 {
+  flex-basis: calc(100% * 1 / 6) !important;
   width: calc(100% * 1 / 6) !important;
 }
 
 .u-size1of5,
 .u-size2of10 {
+  flex-basis: 20% !important;
   width: 20% !important;
 }
 
 .u-size1of4,
 .u-size2of8,
 .u-size3of12 {
+  flex-basis: 25% !important;
   width: 25% !important;
 }
 
 .u-size3of10 {
+  flex-basis: 30% !important;
   width: 30% !important;
 }
 
 .u-size1of3,
 .u-size2of6,
 .u-size4of12 {
+  flex-basis: calc(100% * 1 / 3) !important;
   width: calc(100% * 1 / 3) !important;
 }
 
 .u-size3of8 {
+  flex-basis: 37.5% !important;
   width: 37.5% !important;
 }
 
 .u-size2of5,
 .u-size4of10 {
+  flex-basis: 40% !important;
   width: 40% !important;
 }
 
 .u-size5of12 {
+  flex-basis: calc(100% * 5 / 12) !important;
   width: calc(100% * 5 / 12) !important;
 }
 
@@ -119,56 +81,68 @@
 .u-size4of8,
 .u-size5of10,
 .u-size6of12 {
+  flex-basis: 50% !important;
   width: 50% !important;
 }
 
 .u-size7of12 {
+  flex-basis: calc(100% * 7 / 12) !important;
   width: calc(100% * 7 / 12) !important;
 }
 
 .u-size3of5,
 .u-size6of10 {
+  flex-basis: 60% !important;
   width: 60% !important;
 }
 
 .u-size5of8 {
+  flex-basis: 62.5% !important;
   width: 62.5% !important;
 }
 
 .u-size2of3,
 .u-size4of6,
 .u-size8of12 {
+  flex-basis: calc(100% * 2 / 3) !important;
   width: calc(100% * 2 / 3) !important;
 }
 
 .u-size7of10 {
+  flex-basis: 70% !important;
   width: 70% !important;
 }
 
 .u-size3of4,
 .u-size6of8,
 .u-size9of12 {
+  flex-basis: 75% !important;
   width: 75% !important;
 }
 
 .u-size4of5,
 .u-size8of10 {
+  flex-basis: 80% !important;
   width: 80% !important;
 }
 
 .u-size5of6,
 .u-size10of12 {
+  flex-basis: calc(100% * 5 / 6) !important;
   width: calc(100% * 5 / 6) !important;
 }
 
 .u-size7of8 {
+  flex-basis: 87.5% !important;
   width: 87.5% !important;
 }
 
 .u-size9of10 {
+  flex-basis: 90% !important;
   width: 90% !important;
 }
 
 .u-size11of12 {
+  flex-basis: calc(100% * 11 / 12) !important;
   width: calc(100% * 11 / 12) !important;
 }

--- a/lib/size.css
+++ b/lib/size.css
@@ -10,12 +10,15 @@
 /**
  * Make an element fill the remaining space.
  *
- * Be explicit to workaround IE10 bug with shorthand flex
- * https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+ * 1. Be explicit to work around IE10 bug with shorthand flex
+ *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+ * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes
+ *    https://github.com/philipwalton/flexbugs#13-importance-is-ignored-on-flex-basis-when-using-flex-shorthand
  */
 
 .u-sizeFill {
   flex: 1 1 0% !important; /* 1 */
+  flex-basis: 0% !important; /* 2 */
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,15 +9,23 @@
     "lib"
   ],
   "devDependencies": {
-    "suitcss-preprocessor": "~0.3.0",
-    "suitcss-components-test": "*"
+    "suitcss-components-test": "*",
+    "autoprefixer": "^6.0.3",
+    "postcss": "^5.0.10",
+    "postcss-bem-linter": "^2.0.0",
+    "postcss-calc": "^5.0.0",
+    "postcss-cli": "^2.3.2",
+    "postcss-custom-media": "^5.0.0",
+    "postcss-import": "^7.1.0",
+    "postcss-reporter": "^1.3.0"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",
     "build-test": "npm run setup && npm run preprocess-test",
-    "preprocess": "suitcss index.css build/build.css",
-    "preprocess-test": "suitcss test/test.css build/test.css",
-    "setup": "npm install && mkdir -p build"
+    "preprocess": "postcss -c build.js -o build/build.css index.css",
+    "preprocess-test": "postcss -c build.js -o build/test.css test/test.css",
+    "setup": "npm install && mkdir -p build",
+    "watch": "npm run preprocess-test -- -w"
   },
   "repository": {
     "type": "git",

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,13 @@
     display: flex;
   }
 
+  .u-flexStart {
+    -webkit-box-align: start;
+    -webkit-align-items: flex-start;
+        -ms-flex-align: start;
+            align-items: flex-start;
+  }
+
   .u-fullWidthFlex {
     -webkit-box-flex: 0;
       -webkit-flex: 0 0 100%;
@@ -38,6 +45,25 @@
 
 <div class="Test">
   <h1 class="Test-title">SUIT CSS: <a href="https://github.com/suitcss/utils-size">sizing utility</a> tests</h1>
+
+  <h2 class="Test-describe">.u-sizeFill</h2>
+  <h3 class="Test-it">fills remaining space</h3>
+  <div class="Test-run">
+    <div class="u-displayFlex u-flexStart">
+      <div class="dev-Box"></div>
+      <div class="u-sizeFill u-highlight">
+        content
+      </div>
+    </div>
+  </div>
+
+  <h2 class="Test-describe">.u-sizeFull</h2>
+  <h3 class="Test-it">fits the full-width of the container</h3>
+  <div class="Test-run">
+    <div class="u-sizeFull u-highlight" style="border:10px solid red;">
+      content
+    </div>
+  </div>
 
   <h2 class="Test-describe">.u-sizeXof2</h2>
   <h3 class="Test-it">sizes to 1/2 of the parent container</h3>

--- a/test/index.html
+++ b/test/index.html
@@ -25,53 +25,6 @@
 <div class="Test">
   <h1 class="Test-title">SUIT CSS: <a href="https://github.com/suitcss/utils-size">sizing utility</a> tests</h1>
 
-  <h2 class="Test-describe">.u-sizeFit / .u-sizeFill</h2>
-  <h3 class="Test-it">shrink-wraps (on left) / fills remaining space</h3>
-  <div class="Test-run">
-    <div class="u-cf">
-      <div class="u-sizeFit">
-        <div class="dev-Box"></div>
-      </div>
-      <div class="u-sizeFill u-highlight">
-        content
-      </div>
-    </div>
-  </div>
-
-  <h2 class="Test-describe">.u-sizeFit / .u-sizeFillAlt</h2>
-  <h3 class="Test-it">shrink-wraps (on left) / fills remaining space</h3>
-  <div class="Test-run">
-    <div class="u-cf">
-      <div class="u-sizeFit">
-        <div class="dev-Box"></div>
-      </div>
-      <div class="u-sizeFillAlt u-highlight">
-        content
-      </div>
-    </div>
-  </div>
-
-  <h2 class="Test-describe">.u-sizeFitAlt / .u-sizeFill</h2>
-  <h3 class="Test-it">shrink-wraps (on right) / fills remaining space</h3>
-  <div class="Test-run">
-    <div class="u-cf">
-      <div class="u-sizeFitAlt">
-        <div class="dev-Box"></div>
-      </div>
-      <div class="u-sizeFill u-highlight">
-        content
-      </div>
-    </div>
-  </div>
-
-  <h2 class="Test-describe">.u-sizeFull</h2>
-  <h3 class="Test-it">fits the full-width of the container</h3>
-  <div class="Test-run">
-    <div class="u-sizeFull u-highlight" style="border:10px solid red;">
-      content
-    </div>
-  </div>
-
   <h2 class="Test-describe">.u-sizeXof2</h2>
   <h3 class="Test-it">sizes to 1/2 of the parent container</h3>
   <div class="Test-run">

--- a/test/index.html
+++ b/test/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Size [utility] - SUIT CSS</title>
 <meta name="viewport" content="initial-scale=1, width=device-width">
-<link rel="stylesheet" href="../build/build.css">
+<link rel="stylesheet" href="../build/test.css">
 <style>
   .u-cf:after {
     clear: both;

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,20 @@
     margin: 0 0 10px;
   }
 
+  .u-displayFlex {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+
+  .u-fullWidthFlex {
+    -webkit-box-flex: 0;
+      -webkit-flex: 0 0 100%;
+          -ms-flex: 0 0 100%;
+              flex: 0 0 100%;
+  }
+
   .dev-Box {
     background: red;
     height: 50px;
@@ -28,58 +42,139 @@
   <h2 class="Test-describe">.u-sizeXof2</h2>
   <h3 class="Test-it">sizes to 1/2 of the parent container</h3>
   <div class="Test-run">
-    <div class="u-size1of2 u-highlight">1of2</div>
+    <div class="u-size1of2 u-highlight">1of2 width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of2 u-highlight u-fullWidthFlex">1of2 flex-basis</div>
   </div>
 
   <h2 class="Test-describe">.u-sizeXof3</h2>
   <h3 class="Test-it">sizes to 1/3 of the parent container</h3>
   <div class="Test-run">
-    <div class="u-size1of3 u-highlight">1of3</div>
-    <div class="u-size2of3 u-highlight">2of3</div>
+    <div class="u-size1of3 u-highlight">1of3 width</div>
+    <div class="u-size2of3 u-highlight">2of3 width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of3 u-highlight u-fullWidthFlex">1of3 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size2of3 u-highlight u-fullWidthFlex">2of3 flex-basis</div>
   </div>
 
   <h2 class="Test-describe">.u-sizeXof4</h2>
   <h3 class="Test-it">sizes to 1/4 of the parent container</h3>
   <div class="Test-run">
-    <div class="u-size1of4 u-highlight">1of4</div>
-    <div class="u-size2of4 u-highlight">2of4</div>
-    <div class="u-size3of4 u-highlight">3of4</div>
+    <div class="u-size1of4 u-highlight">1of4 width</div>
+    <div class="u-size2of4 u-highlight">2of4 width</div>
+    <div class="u-size3of4 u-highlight">3of4 width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of4 u-highlight u-fullWidthFlex">1of4 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size2of4 u-highlight u-fullWidthFlex">2of4 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size3of4 u-highlight u-fullWidthFlex">3of4 flex-basis</div>
   </div>
 
   <h2 class="Test-describe">.u-sizeXof6</h2>
   <h3 class="Test-it">sizes to 1/6 of the parent container</h3>
   <div class="Test-run">
-    <div class="u-size1of6 u-highlight">1of6</div>
-    <div class="u-size2of6 u-highlight">2of6</div>
-    <div class="u-size3of6 u-highlight">3of6</div>
-    <div class="u-size4of6 u-highlight">4of6</div>
-    <div class="u-size5of6 u-highlight">5of6</div>
+    <div class="u-size1of6 u-highlight">1of6 width</div>
+    <div class="u-size2of6 u-highlight">2of6 width</div>
+    <div class="u-size3of6 u-highlight">3of6 width</div>
+    <div class="u-size4of6 u-highlight">4of6 width</div>
+    <div class="u-size5of6 u-highlight">5of6 width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of6 u-highlight u-fullWidthFlex">1of6 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size2of6 u-highlight u-fullWidthFlex">2of6 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size3of6 u-highlight u-fullWidthFlex">3of6 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size4of6 u-highlight u-fullWidthFlex">4of6 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size5of6 u-highlight u-fullWidthFlex">5of6 flex-basis</div>
   </div>
 
   <h2 class="Test-describe">.u-sizeXof8</h2>
   <h3 class="Test-it">sizes to 1/8 of the parent container</h3>
   <div class="Test-run">
-    <div class="u-size1of8 u-highlight">1of8</div>
-    <div class="u-size2of8 u-highlight">2of8</div>
-    <div class="u-size3of8 u-highlight">3of8</div>
-    <div class="u-size4of8 u-highlight">4of8</div>
-    <div class="u-size5of8 u-highlight">5of8</div>
-    <div class="u-size6of8 u-highlight">6of8</div>
-    <div class="u-size7of8 u-highlight">7of8</div>
+    <div class="u-size1of8 u-highlight">1of8 width</div>
+    <div class="u-size2of8 u-highlight">2of8 width</div>
+    <div class="u-size3of8 u-highlight">3of8 width</div>
+    <div class="u-size4of8 u-highlight">4of8 width</div>
+    <div class="u-size5of8 u-highlight">5of8 width</div>
+    <div class="u-size6of8 u-highlight">6of8 width</div>
+    <div class="u-size7of8 u-highlight">7of8 width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of8 u-highlight u-fullWidthFlex">1of8 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size2of8 u-highlight u-fullWidthFlex">2of8 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size3of8 u-highlight u-fullWidthFlex">3of8 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size4of8 u-highlight u-fullWidthFlex">4of8 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size5of8 u-highlight u-fullWidthFlex">5of8 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size6of8 u-highlight u-fullWidthFlex">6of8 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size7of8 u-highlight u-fullWidthFlex">7of8 flex-basis</div>
   </div>
 
   <h2 class="Test-describe">.u-sizeXof10</h2>
   <h3 class="Test-it">sizes to 1/10 of the parent container</h3>
   <div class="Test-run">
-    <div class="u-size1of10 u-highlight">1of10</div>
-    <div class="u-size2of10 u-highlight">2of10</div>
-    <div class="u-size3of10 u-highlight">3of10</div>
-    <div class="u-size4of10 u-highlight">4of10</div>
-    <div class="u-size5of10 u-highlight">5of10</div>
-    <div class="u-size6of10 u-highlight">6of10</div>
-    <div class="u-size7of10 u-highlight">7of10</div>
-    <div class="u-size8of10 u-highlight">8of10</div>
-    <div class="u-size9of10 u-highlight">9of10</div>
+    <div class="u-size1of10 u-highlight">1of10 width</div>
+    <div class="u-size2of10 u-highlight">2of10 width</div>
+    <div class="u-size3of10 u-highlight">3of10 width</div>
+    <div class="u-size4of10 u-highlight">4of10 width</div>
+    <div class="u-size5of10 u-highlight">5of10 width</div>
+    <div class="u-size6of10 u-highlight">6of10 width</div>
+    <div class="u-size7of10 u-highlight">7of10 width</div>
+    <div class="u-size8of10 u-highlight">8of10 width</div>
+    <div class="u-size9of10 u-highlight">9of10 width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of10 u-highlight u-fullWidthFlex">1of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size2of10 u-highlight u-fullWidthFlex">2of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size3of10 u-highlight u-fullWidthFlex">3of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size4of10 u-highlight u-fullWidthFlex">4of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size5of10 u-highlight u-fullWidthFlex">5of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size6of10 u-highlight u-fullWidthFlex">6of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size7of10 u-highlight u-fullWidthFlex">7of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size8of10 u-highlight u-fullWidthFlex">8of10 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size9of10 u-highlight u-fullWidthFlex">9of10 flex-basis</div>
   </div>
 
   <h2 class="Test-describe">.u-sizeXof12</h2>
@@ -97,10 +192,46 @@
     <div class="u-size10of12 u-highlight">10of12</div>
     <div class="u-size11of12 u-highlight">11of12</div>
   </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size1of12 u-highlight u-fullWidthFlex">1of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size2of12 u-highlight u-fullWidthFlex">2of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size3of12 u-highlight u-fullWidthFlex">3of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size4of12 u-highlight u-fullWidthFlex">4of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size5of12 u-highlight u-fullWidthFlex">5of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size6of12 u-highlight u-fullWidthFlex">6of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size7of12 u-highlight u-fullWidthFlex">7of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size8of12 u-highlight u-fullWidthFlex">8of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size9of12 u-highlight u-fullWidthFlex">9of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size10of12 u-highlight u-fullWidthFlex">10of12 flex-basis</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-size11of12 u-highlight u-fullWidthFlex">11of12 flex-basis</div>
+  </div>
 
   <h2 class="Test-describe">.u-sm-sizeXof12 .u-md-sizeXof12 .u-lg-sizeXof12</h2>
   <h3 class="Test-it">adapts the width at different viewport sizes</h3>
   <div class="Test-run">
-    <div class="u-size12of12 u-sm-size9of12 u-md-size6of12 u-lg-size3of12 u-highlight">12of12 -> 9of12 -> 6of12 -> 3of12</div>
+    <div class="u-sm-size9of12 u-md-size6of12 u-lg-size3of12 u-highlight">12of12 -> 9of12 -> 6of12 -> 3of12 - width</div>
+  </div>
+  <div class="Test-run u-displayFlex">
+    <div class="u-sm-size9of12 u-md-size6of12 u-lg-size3of12 u-highlight u-fullWidthFlex">12of12 -> 9of12 -> 6of12 -> 3of12 - flex-basis</div>
   </div>
 </div>


### PR DESCRIPTION
These changes support the [proposed flexbox grid](https://github.com/suitcss/components-grid/pull/39)

Removes float based tools and adds `flex-basis` alongside width

Tests: 
https://dl.dropboxusercontent.com/u/1709558/utils-size/index.html

Expect this to fix #25 and #22 as those selectors will no longer exist.