### PR TITLE
Add sizeFillAlt

### DIFF
--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -21,6 +21,18 @@
   }
 
   /**
+   * An alternative method to make an element fill the remaining space.
+   * Distributes space based on the initial width and height of the element
+   *
+   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+   */
+
+  .u-lg-sizeFillAlt {
+    flex: 1 1 auto !important;
+    flex-basis: auto !important;
+  }
+
+  /**
    * Make an element the width of its parent.
    */
 

--- a/lib/size-lg.css
+++ b/lib/size-lg.css
@@ -5,43 +5,6 @@
 
 @media (--lg-viewport) {
 
-  /* Intrinsic widths
-     ========================================================================== */
-
-  /**
-   * Make an element fill the remaining space.
-   *
-   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
-   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
-   */
-
-  .u-lg-sizeFill {
-    flex: 1 1 0% !important; /* 1 */
-    flex-basis: 0% !important; /* 2 */
-  }
-
-  /**
-   * An alternative method to make an element fill the remaining space.
-   * Distributes space based on the initial width and height of the element
-   *
-   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
-   */
-
-  .u-lg-sizeFillAlt {
-    flex: 1 1 auto !important;
-    flex-basis: auto !important;
-  }
-
-  /**
-   * Make an element the width of its parent.
-   */
-
-  .u-lg-sizeFull {
-    box-sizing: border-box !important;
-    display: block !important;
-    width: 100% !important;
-  }
-
   /* Proportional widths: breakpoint 3 (large)
      ========================================================================== */
 
@@ -50,13 +13,13 @@
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
    *
-   * Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
-   * http://git.io/vllMD
+   * 1. Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
+   *    http://git.io/vllMD
    */
 
   /* postcss-bem-linter: ignore */
   [class*="u-lg-size"] {
-    flex-basis: auto !important;
+    flex-basis: auto !important; /* 1 */
   }
 
   .u-lg-size1of12 {
@@ -168,6 +131,43 @@
 
   .u-lg-size11of12 {
     width: calc(100% * 11 / 12) !important;
+  }
+
+  /* Intrinsic widths
+     ========================================================================== */
+
+  /**
+   * Make an element fill the remaining space.
+   *
+   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
+   */
+
+  .u-lg-sizeFill {
+    flex: 1 1 0% !important; /* 1 */
+    flex-basis: 0% !important; /* 2 */
+  }
+
+  /**
+   * An alternative method to make an element fill the remaining space.
+   * Distributes space based on the initial width and height of the element
+   *
+   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+   */
+
+  .u-lg-sizeFillAlt {
+    flex: 1 1 auto !important;
+    flex-basis: auto !important;
+  }
+
+  /**
+   * Make an element the width of its parent.
+   */
+
+  .u-lg-sizeFull {
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
   }
 
 }

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -5,43 +5,6 @@
 
 @media (--md-viewport) {
 
-  /* Intrinsic widths
-     ========================================================================== */
-
-  /**
-   * Make an element fill the remaining space.
-   *
-   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
-   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
-   */
-
-  .u-md-sizeFill {
-    flex: 1 1 0% !important; /* 1 */
-    flex-basis: 0% !important; /* 2 */
-  }
-
-  /**
-   * An alternative method to make an element fill the remaining space.
-   * Distributes space based on the initial width and height of the element
-   *
-   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
-   */
-
-  .u-md-sizeFillAlt {
-    flex: 1 1 auto !important;
-    flex-basis: auto !important;
-  }
-
-  /**
-   * Make an element the width of its parent.
-   */
-
-  .u-md-sizeFull {
-    box-sizing: border-box !important;
-    display: block !important;
-    width: 100% !important;
-  }
-
   /* Proportional widths: breakpoint 2 (medium)
      ========================================================================== */
 
@@ -50,13 +13,13 @@
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
    *
-   * Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
-   * http://git.io/vllMD
+   * 1. Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
+   *    http://git.io/vllMD
    */
 
   /* postcss-bem-linter: ignore */
   [class*="u-md-size"] {
-    flex-basis: auto !important;
+    flex-basis: auto !important; /* 1 */
   }
 
   .u-md-size1of12 {
@@ -168,6 +131,43 @@
 
   .u-md-size11of12 {
     width: calc(100% * 11 / 12) !important;
+  }
+
+  /* Intrinsic widths
+     ========================================================================== */
+
+  /**
+   * Make an element fill the remaining space.
+   *
+   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
+   */
+
+  .u-md-sizeFill {
+    flex: 1 1 0% !important; /* 1 */
+    flex-basis: 0% !important; /* 2 */
+  }
+
+  /**
+   * An alternative method to make an element fill the remaining space.
+   * Distributes space based on the initial width and height of the element
+   *
+   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+   */
+
+  .u-md-sizeFillAlt {
+    flex: 1 1 auto !important;
+    flex-basis: auto !important;
+  }
+
+  /**
+   * Make an element the width of its parent.
+   */
+
+  .u-md-sizeFull {
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
   }
 
 }

--- a/lib/size-md.css
+++ b/lib/size-md.css
@@ -21,6 +21,18 @@
   }
 
   /**
+   * An alternative method to make an element fill the remaining space.
+   * Distributes space based on the initial width and height of the element
+   *
+   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+   */
+
+  .u-md-sizeFillAlt {
+    flex: 1 1 auto !important;
+    flex-basis: auto !important;
+  }
+
+  /**
    * Make an element the width of its parent.
    */
 

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -5,43 +5,6 @@
 
 @media (--sm-viewport) {
 
-  /* Intrinsic widths
-     ========================================================================== */
-
-  /**
-   * Make an element fill the remaining space.
-   *
-   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
-   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
-   */
-
-  .u-sm-sizeFill {
-    flex: 1 1 0% !important; /* 1 */
-    flex-basis: 0% !important; /* 2 */
-  }
-
-  /**
-   * An alternative method to make an element fill the remaining space.
-   * Distributes space based on the initial width and height of the element
-   *
-   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
-   */
-
-  .u-sm-sizeFillAlt {
-    flex: 1 1 auto !important;
-    flex-basis: auto !important;
-  }
-
-  /**
-   * Make an element the width of its parent.
-   */
-
-  .u-sm-sizeFull {
-    box-sizing: border-box !important;
-    display: block !important;
-    width: 100% !important;
-  }
-
   /* Proportional widths: breakpoint 1 (small)
      ========================================================================== */
 
@@ -50,13 +13,13 @@
    * Intentional redundancy build into each set of unit classes.
    * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
    *
-   * Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
-   * http://git.io/vllMD
+   * 1. Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
+   *    http://git.io/vllMD
    */
 
   /* postcss-bem-linter: ignore */
   [class*="u-sm-size"] {
-    flex-basis: auto !important;
+    flex-basis: auto !important; /* 1 */
   }
 
   .u-sm-size1of12 {
@@ -168,6 +131,43 @@
 
   .u-sm-size11of12 {
     width: calc(100% * 11 / 12) !important;
+  }
+
+  /* Intrinsic widths
+     ========================================================================== */
+
+  /**
+   * Make an element fill the remaining space.
+   *
+   * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+   * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
+   */
+
+  .u-sm-sizeFill {
+    flex: 1 1 0% !important; /* 1 */
+    flex-basis: 0% !important; /* 2 */
+  }
+
+  /**
+   * An alternative method to make an element fill the remaining space.
+   * Distributes space based on the initial width and height of the element
+   *
+   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+   */
+
+  .u-sm-sizeFillAlt {
+    flex: 1 1 auto !important;
+    flex-basis: auto !important;
+  }
+
+  /**
+   * Make an element the width of its parent.
+   */
+
+  .u-sm-sizeFull {
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
   }
 
 }

--- a/lib/size-sm.css
+++ b/lib/size-sm.css
@@ -21,6 +21,18 @@
   }
 
   /**
+   * An alternative method to make an element fill the remaining space.
+   * Distributes space based on the initial width and height of the element
+   *
+   * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+   */
+
+  .u-sm-sizeFillAlt {
+    flex: 1 1 auto !important;
+    flex-basis: auto !important;
+  }
+
+  /**
    * Make an element the width of its parent.
    */
 

--- a/lib/size.css
+++ b/lib/size.css
@@ -1,45 +1,7 @@
-
 /**
  * @define utilities
  * Sizing utilities
  */
-
-/* Intrinsic widths
-   ========================================================================== */
-
-/**
- * Make an element fill the remaining space.
- *
- * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
- * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
- */
-
-.u-sizeFill {
-  flex: 1 1 0% !important; /* 1 */
-  flex-basis: 0% !important; /* 2 */
-}
-
-/**
- * An alternative method to make an element fill the remaining space.
- * Distributes space based on the initial width and height of the element
- *
- * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
- */
-
-.u-sizeFillAlt {
-  flex: 1 1 auto !important;
-  flex-basis: auto !important;
-}
-
-/**
- * Make an element the width of its parent.
- */
-
-.u-sizeFull {
-  box-sizing: border-box !important;
-  display: block !important;
-  width: 100% !important;
-}
 
 /* Proportional widths
    ========================================================================== */
@@ -49,13 +11,13 @@
  * Intentional redundancy build into each set of unit classes.
  * Supports: 2, 3, 4, 5, 6, 8, 10, 12 part
  *
- * Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
- * http://git.io/vllMD
+ * 1. Use `flex-basis: auto` with a width to avoid box-sizing bug in IE10/11
+ *    http://git.io/vllMD
  */
 
 /* postcss-bem-linter: ignore */
 [class*="u-size"] {
-  flex-basis: auto !important;
+  flex-basis: auto !important; /* 1 */
 }
 
 .u-size1of12 {
@@ -167,4 +129,41 @@
 
 .u-size11of12 {
   width: calc(100% * 11 / 12) !important;
+}
+
+/* Intrinsic widths
+   ========================================================================== */
+
+/**
+ * Make an element fill the remaining space.
+ *
+ * 1. Be explicit to work around IE10 bug with shorthand flex - http://git.io/vllC7
+ * 2. IE10 ignores previous `flex-basis` value. Setting again here fixes - http://git.io/vllMt
+ */
+
+.u-sizeFill {
+  flex: 1 1 0% !important; /* 1 */
+  flex-basis: 0% !important; /* 2 */
+}
+
+/**
+ * An alternative method to make an element fill the remaining space.
+ * Distributes space based on the initial width and height of the element
+ *
+ * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+ */
+
+.u-sizeFillAlt {
+  flex: 1 1 auto !important;
+  flex-basis: auto !important;
+}
+
+/**
+ * Make an element the width of its parent.
+ */
+
+.u-sizeFull {
+  box-sizing: border-box !important;
+  display: block !important;
+  width: 100% !important;
 }

--- a/lib/size.css
+++ b/lib/size.css
@@ -20,6 +20,18 @@
 }
 
 /**
+ * An alternative method to make an element fill the remaining space.
+ * Distributes space based on the initial width and height of the element
+ *
+ * http://www.w3.org/TR/css-flexbox/images/rel-vs-abs-flex.svg
+ */
+
+.u-sizeFillAlt {
+  flex: 1 1 auto !important;
+  flex-basis: auto !important;
+}
+
+/**
  * Make an element the width of its parent.
  */
 

--- a/test/index.html
+++ b/test/index.html
@@ -32,7 +32,7 @@
 <div class="Test">
   <h1 class="Test-title">SUIT CSS: <a href="https://github.com/suitcss/utils-size">sizing utility</a> tests</h1>
 
-  <h2 class="Test-describe">.u-sizeFill</h2>
+  <h2 class="Test-describe">.u-sizeFill / .u-sizeFillAlt</h2>
   <h3 class="Test-it">fills remaining space</h3>
   <div class="Test-run">
     <div class="u-flex">
@@ -70,6 +70,38 @@
         content
       </div>
       <div class="u-sizeFill u-highlight">
+        content
+      </div>
+    </div>
+  </div>
+
+  <h2 class="Test-describe">.u-sizeFillAlt</h2>
+  <h3 class="Test-it">distributes space based on initial width of item</h3>
+  <div class="Test-run">
+    <div class="u-flex">
+      <div class="u-sizeFillAlt u-highlight">
+        Lorem ipsum dolor sit amet, probo option similique vix te, ei summo
+        aliquip nec. Atqui diceret ceteros. Lorem ipsum dolor sit amet.
+      </div>
+      <div class="u-sizeFillAlt u-highlight">
+        content
+      </div>
+      <div class="u-sizeFillAlt u-highlight">
+        content
+      </div>
+    </div>
+  </div>
+  <div class="Test-run">
+    <div class="u-flex">
+      <div class="dev-Box"></div>
+      <div class="u-sizeFillAlt u-highlight">
+        Lorem ipsum dolor sit amet, probo option similique vix te, ei summo
+        aliquip nec. Atqui diceret ceteros.
+      </div>
+     <div class="u-sizeFillAlt u-highlight">
+        content
+      </div>
+      <div class="u-sizeFillAlt u-highlight">
         content
       </div>
     </div>

--- a/test/index.html
+++ b/test/index.html
@@ -15,13 +15,6 @@
     margin: 0 0 10px;
   }
 
-  .u-flexStart {
-    -webkit-box-align: start;
-    -webkit-align-items: flex-start;
-        -ms-flex-align: start;
-            align-items: flex-start;
-  }
-
   .u-fullWidthFlex {
     -webkit-box-flex: 0;
       -webkit-flex: 0 0 100%;
@@ -42,7 +35,7 @@
   <h2 class="Test-describe">.u-sizeFill</h2>
   <h3 class="Test-it">fills remaining space</h3>
   <div class="Test-run">
-    <div class="u-flex u-flexStart">
+    <div class="u-flex">
       <div class="dev-Box"></div>
       <div class="u-sizeFill u-highlight">
         content
@@ -67,7 +60,7 @@
     </div>
   </div>
   <div class="Test-run">
-    <div class="u-flex u-flexStart">
+    <div class="u-flex">
       <div class="dev-Box"></div>
       <div class="u-sizeFill u-highlight">
         Lorem ipsum dolor sit amet, probo option similique vix te, ei summo

--- a/test/index.html
+++ b/test/index.html
@@ -50,6 +50,38 @@
     </div>
   </div>
 
+  <h2 class="Test-describe">.u-sizeFill</h2>
+  <h3 class="Test-it">distributes space evenly</h3>
+  <div class="Test-run" style="margin-bottom: 15px">
+    <div class="u-flex">
+      <div class="u-sizeFill u-highlight">
+        Lorem ipsum dolor sit amet, probo option similique vix te, ei summo
+        aliquip nec. Atqui diceret ceteros.
+      </div>
+      <div class="u-sizeFill u-highlight">
+        content
+      </div>
+      <div class="u-sizeFill u-highlight">
+        content
+      </div>
+    </div>
+  </div>
+  <div class="Test-run">
+    <div class="u-flex u-flexStart">
+      <div class="dev-Box"></div>
+      <div class="u-sizeFill u-highlight">
+        Lorem ipsum dolor sit amet, probo option similique vix te, ei summo
+        aliquip nec. Atqui diceret ceteros.
+      </div>
+     <div class="u-sizeFill u-highlight">
+        content
+      </div>
+      <div class="u-sizeFill u-highlight">
+        content
+      </div>
+    </div>
+  </div>
+
   <h2 class="Test-describe">.u-sizeFull</h2>
   <h3 class="Test-it">fits the full-width of the container</h3>
   <div class="Test-run">


### PR DESCRIPTION
This re-introduces `sizeFillAlt` which uses `flex-basis: auto` as opposed to `0` in `sizeFill`. This will hopefully be useful to use alongside the `utils-flex` which is nearly done.

<img width="1188" alt="screen shot 2015-11-15 at 15 27 14" src="https://cloud.githubusercontent.com/assets/360703/11169370/61fbf604-8bad-11e5-9502-942e85f682c0.png">

Added some more tests to demonstrate.

Additionally I added more explicit selectors for applying `flex-basis: auto` to `sizeXofY` as the previous catch all selector was effecting the `sizeFit/Full` rules.